### PR TITLE
Allow ruby versions greater than 2.5.0 for contributor Gemfile

### DIFF
--- a/contributions/Gemfile
+++ b/contributions/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '2.5.0'
+ruby '~> 2.5.0'
 
- gem 'rack-ssl-enforcer'
+gem 'rack-ssl-enforcer'
 gem 'dotenv'
 gem 'foreman'
 gem 'json'


### PR DESCRIPTION
Not sure if there is a reason why the Gemfile has been locked at 2.5.0 but getting things setup on my version of Ruby on WSL was 2.5.1 and the gems couldn't be installed. I've updated the ruby version to be 2.5.0 or greater.