### PR TITLE
Ignore vendor folder in contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .bundle/
 yarn-error.log
 /vendor/bundle/
+/contributions/vendor/bundle
 
 ###################
 # Build artefacts


### PR DESCRIPTION
Ignores the vendor folder output in the contributions folder when building the source.